### PR TITLE
Inject rel=canonical in ipython 2 and 3 docs

### DIFF
--- a/2/about/history.html
+++ b/2/about/history.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/about/history.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/about/index.html
+++ b/2/about/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/about/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/about/license_and_copyright.html
+++ b/2/about/license_and_copyright.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/about/license_and_copyright.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.alias.html
+++ b/2/api/generated/IPython.core.alias.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.alias.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.application.html
+++ b/2/api/generated/IPython.core.application.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.application.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.autocall.html
+++ b/2/api/generated/IPython.core.autocall.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.autocall.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.builtin_trap.html
+++ b/2/api/generated/IPython.core.builtin_trap.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.builtin_trap.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.compilerop.html
+++ b/2/api/generated/IPython.core.compilerop.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.compilerop.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.completer.html
+++ b/2/api/generated/IPython.core.completer.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.completer.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.completerlib.html
+++ b/2/api/generated/IPython.core.completerlib.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.completerlib.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.crashhandler.html
+++ b/2/api/generated/IPython.core.crashhandler.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.crashhandler.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.debugger.html
+++ b/2/api/generated/IPython.core.debugger.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.debugger.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.error.html
+++ b/2/api/generated/IPython.core.error.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.error.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.events.html
+++ b/2/api/generated/IPython.core.events.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.events.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.excolors.html
+++ b/2/api/generated/IPython.core.excolors.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.excolors.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.extensions.html
+++ b/2/api/generated/IPython.core.extensions.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.extensions.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.formatters.html
+++ b/2/api/generated/IPython.core.formatters.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.formatters.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.getipython.html
+++ b/2/api/generated/IPython.core.getipython.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.getipython.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.history.html
+++ b/2/api/generated/IPython.core.history.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.history.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.historyapp.html
+++ b/2/api/generated/IPython.core.historyapp.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.historyapp.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.hooks.html
+++ b/2/api/generated/IPython.core.hooks.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.hooks.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.inputsplitter.html
+++ b/2/api/generated/IPython.core.inputsplitter.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.inputsplitter.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.inputtransformer.html
+++ b/2/api/generated/IPython.core.inputtransformer.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.inputtransformer.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.interactiveshell.html
+++ b/2/api/generated/IPython.core.interactiveshell.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.interactiveshell.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.logger.html
+++ b/2/api/generated/IPython.core.logger.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.logger.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.macro.html
+++ b/2/api/generated/IPython.core.macro.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.macro.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.magic.html
+++ b/2/api/generated/IPython.core.magic.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.magic.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.magic_arguments.html
+++ b/2/api/generated/IPython.core.magic_arguments.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.magic_arguments.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.oinspect.html
+++ b/2/api/generated/IPython.core.oinspect.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.oinspect.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.page.html
+++ b/2/api/generated/IPython.core.page.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.page.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.payload.html
+++ b/2/api/generated/IPython.core.payload.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.payload.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.payloadpage.html
+++ b/2/api/generated/IPython.core.payloadpage.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.payloadpage.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.prefilter.html
+++ b/2/api/generated/IPython.core.prefilter.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.prefilter.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.profileapp.html
+++ b/2/api/generated/IPython.core.profileapp.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.profileapp.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.profiledir.html
+++ b/2/api/generated/IPython.core.profiledir.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.profiledir.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.prompts.html
+++ b/2/api/generated/IPython.core.prompts.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.prompts.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.pylabtools.html
+++ b/2/api/generated/IPython.core.pylabtools.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.pylabtools.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.shellapp.html
+++ b/2/api/generated/IPython.core.shellapp.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.shellapp.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.splitinput.html
+++ b/2/api/generated/IPython.core.splitinput.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.splitinput.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.core.ultratb.html
+++ b/2/api/generated/IPython.core.ultratb.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.ultratb.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.html
+++ b/2/api/generated/IPython.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.backgroundjobs.html
+++ b/2/api/generated/IPython.lib.backgroundjobs.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.backgroundjobs.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.clipboard.html
+++ b/2/api/generated/IPython.lib.clipboard.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.clipboard.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.deepreload.html
+++ b/2/api/generated/IPython.lib.deepreload.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.deepreload.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.demo.html
+++ b/2/api/generated/IPython.lib.demo.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.demo.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.editorhooks.html
+++ b/2/api/generated/IPython.lib.editorhooks.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.editorhooks.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.guisupport.html
+++ b/2/api/generated/IPython.lib.guisupport.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.guisupport.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.inputhook.html
+++ b/2/api/generated/IPython.lib.inputhook.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.inputhook.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.latextools.html
+++ b/2/api/generated/IPython.lib.latextools.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.latextools.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.pretty.html
+++ b/2/api/generated/IPython.lib.pretty.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.pretty.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.lib.security.html
+++ b/2/api/generated/IPython.lib.security.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.lib.security.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.terminal.embed.html
+++ b/2/api/generated/IPython.terminal.embed.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.terminal.embed.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.terminal.interactiveshell.html
+++ b/2/api/generated/IPython.terminal.interactiveshell.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.terminal.interactiveshell.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.terminal.ipapp.html
+++ b/2/api/generated/IPython.terminal.ipapp.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.terminal.ipapp.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.testing.decorators.html
+++ b/2/api/generated/IPython.testing.decorators.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.testing.decorators.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.testing.globalipapp.html
+++ b/2/api/generated/IPython.testing.globalipapp.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.testing.globalipapp.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.testing.html
+++ b/2/api/generated/IPython.testing.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.testing.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.testing.iptest.html
+++ b/2/api/generated/IPython.testing.iptest.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.testing.iptest.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.testing.iptestcontroller.html
+++ b/2/api/generated/IPython.testing.iptestcontroller.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.testing.iptestcontroller.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.testing.ipunittest.html
+++ b/2/api/generated/IPython.testing.ipunittest.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.testing.ipunittest.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.testing.skipdoctest.html
+++ b/2/api/generated/IPython.testing.skipdoctest.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.testing.skipdoctest.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.testing.tools.html
+++ b/2/api/generated/IPython.testing.tools.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.testing.tools.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.PyColorize.html
+++ b/2/api/generated/IPython.utils.PyColorize.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.PyColorize.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.capture.html
+++ b/2/api/generated/IPython.utils.capture.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.capture.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.coloransi.html
+++ b/2/api/generated/IPython.utils.coloransi.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.coloransi.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.contexts.html
+++ b/2/api/generated/IPython.utils.contexts.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.contexts.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.data.html
+++ b/2/api/generated/IPython.utils.data.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.data.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.decorators.html
+++ b/2/api/generated/IPython.utils.decorators.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.decorators.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.dir2.html
+++ b/2/api/generated/IPython.utils.dir2.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.dir2.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.encoding.html
+++ b/2/api/generated/IPython.utils.encoding.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.encoding.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.frame.html
+++ b/2/api/generated/IPython.utils.frame.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.frame.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.generics.html
+++ b/2/api/generated/IPython.utils.generics.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.generics.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.importstring.html
+++ b/2/api/generated/IPython.utils.importstring.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.importstring.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.io.html
+++ b/2/api/generated/IPython.utils.io.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.io.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.ipstruct.html
+++ b/2/api/generated/IPython.utils.ipstruct.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.ipstruct.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.module_paths.html
+++ b/2/api/generated/IPython.utils.module_paths.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.module_paths.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.openpy.html
+++ b/2/api/generated/IPython.utils.openpy.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.openpy.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.path.html
+++ b/2/api/generated/IPython.utils.path.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.path.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.process.html
+++ b/2/api/generated/IPython.utils.process.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.process.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.rlineimpl.html
+++ b/2/api/generated/IPython.utils.rlineimpl.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.rlineimpl.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.strdispatch.html
+++ b/2/api/generated/IPython.utils.strdispatch.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.strdispatch.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.sysinfo.html
+++ b/2/api/generated/IPython.utils.sysinfo.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.sysinfo.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.syspathcontext.html
+++ b/2/api/generated/IPython.utils.syspathcontext.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.syspathcontext.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.tempdir.html
+++ b/2/api/generated/IPython.utils.tempdir.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.tempdir.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.terminal.html
+++ b/2/api/generated/IPython.utils.terminal.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.terminal.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.text.html
+++ b/2/api/generated/IPython.utils.text.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.text.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.timing.html
+++ b/2/api/generated/IPython.utils.timing.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.timing.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.tz.html
+++ b/2/api/generated/IPython.utils.tz.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.tz.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.ulinecache.html
+++ b/2/api/generated/IPython.utils.ulinecache.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.ulinecache.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.version.html
+++ b/2/api/generated/IPython.utils.version.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.version.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/generated/IPython.utils.wildcard.html
+++ b/2/api/generated/IPython.utils.wildcard.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.utils.wildcard.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/api/index.html
+++ b/2/api/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/callbacks.html
+++ b/2/config/callbacks.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/callbacks.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/details.html
+++ b/2/config/details.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/details.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/extensions/autoreload.html
+++ b/2/config/extensions/autoreload.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/extensions/autoreload.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/extensions/index.html
+++ b/2/config/extensions/index.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/extensions/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/extensions/storemagic.html
+++ b/2/config/extensions/storemagic.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/extensions/storemagic.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/index.html
+++ b/2/config/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/inputtransforms.html
+++ b/2/config/inputtransforms.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/inputtransforms.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/integrating.html
+++ b/2/config/integrating.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/integrating.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/intro.html
+++ b/2/config/intro.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/intro.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/options/index.html
+++ b/2/config/options/index.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/options/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/options/kernel.html
+++ b/2/config/options/kernel.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/options/kernel.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/config/options/terminal.html
+++ b/2/config/options/terminal.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/config/options/terminal.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/development/config.html
+++ b/2/development/config.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/development/config.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/development/index.html
+++ b/2/development/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/development/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/development/inputhook_app.html
+++ b/2/development/inputhook_app.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/development/inputhook_app.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/development/lexer.html
+++ b/2/development/lexer.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/development/lexer.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/development/messaging.html
+++ b/2/development/messaging.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/development/messaging.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/development/parallel_connections.html
+++ b/2/development/parallel_connections.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/development/parallel_connections.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/development/parallel_messages.html
+++ b/2/development/parallel_messages.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/development/parallel_messages.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/development/pycompat.html
+++ b/2/development/pycompat.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/development/pycompat.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/genindex.html
+++ b/2/genindex.html
@@ -29,7 +29,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/genindex.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/index.html
+++ b/2/index.html
@@ -29,7 +29,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/install/index.html
+++ b/2/install/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/install/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/install/install.html
+++ b/2/install/install.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/install/install.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/interactive/htmlnotebook.html
+++ b/2/interactive/htmlnotebook.html
@@ -2,7 +2,8 @@
     <head>
         <meta http-equiv="Refresh" content="0; url=../notebook/index.html" />
         <title>Notebook docs have moved</title>
-    </head>
+       <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/htmlnotebook.html"/>
+</head>
     <body>
         <p>The notebook docs have moved <a href="../notebook/index.html">here</a>.</p>
     </body>

--- a/2/interactive/index.html
+++ b/2/interactive/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/interactive/nbconvert.html
+++ b/2/interactive/nbconvert.html
@@ -2,7 +2,8 @@
     <head>
         <meta http-equiv="Refresh" content="0; url=../notebook/index.html" />
         <title>Notebook docs have moved</title>
-    </head>
+       <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/nbconvert.html"/>
+</head>
     <body>
         <p>The notebook docs have moved <a href="../notebook/index.html">here</a>.</p>
     </body>

--- a/2/interactive/notebook.html
+++ b/2/interactive/notebook.html
@@ -2,7 +2,8 @@
     <head>
         <meta http-equiv="Refresh" content="0; url=../notebook/index.html" />
         <title>Notebook docs have moved</title>
-    </head>
+       <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/notebook.html"/>
+</head>
     <body>
         <p>The notebook docs have moved <a href="../notebook/index.html">here</a>.</p>
     </body>

--- a/2/interactive/public_server.html
+++ b/2/interactive/public_server.html
@@ -2,7 +2,8 @@
     <head>
         <meta http-equiv="Refresh" content="0; url=../notebook/index.html" />
         <title>Notebook docs have moved</title>
-    </head>
+       <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/public_server.html"/>
+</head>
     <body>
         <p>The notebook docs have moved <a href="../notebook/index.html">here</a>.</p>
     </body>

--- a/2/interactive/reference.html
+++ b/2/interactive/reference.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/reference.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/interactive/shell.html
+++ b/2/interactive/shell.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/shell.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/interactive/tips.html
+++ b/2/interactive/tips.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/tips.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/interactive/tutorial.html
+++ b/2/interactive/tutorial.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/interactive/tutorial.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/overview.html
+++ b/2/overview.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/overview.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/parallel/index.html
+++ b/2/parallel/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/parallel/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/py-modindex.html
+++ b/2/py-modindex.html
@@ -31,7 +31,8 @@
 
 
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/py-modindex.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/search.html
+++ b/2/search.html
@@ -36,7 +36,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/search.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/development.html
+++ b/2/whatsnew/development.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/development.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/github-stats-0.11.html
+++ b/2/whatsnew/github-stats-0.11.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/github-stats-0.11.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/github-stats-0.12.html
+++ b/2/whatsnew/github-stats-0.12.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/github-stats-0.12.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/github-stats-0.13.html
+++ b/2/whatsnew/github-stats-0.13.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/github-stats-0.13.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/github-stats-1.0.html
+++ b/2/whatsnew/github-stats-1.0.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/github-stats-1.0.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/github-stats-2.0.html
+++ b/2/whatsnew/github-stats-2.0.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/github-stats-2.0.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/index.html
+++ b/2/whatsnew/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/version0.10.html
+++ b/2/whatsnew/version0.10.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/version0.10.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/version0.11.html
+++ b/2/whatsnew/version0.11.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/version0.11.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/version0.12.html
+++ b/2/whatsnew/version0.12.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/version0.12.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/version0.13.html
+++ b/2/whatsnew/version0.13.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/version0.13.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/version0.8.html
+++ b/2/whatsnew/version0.8.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/version0.8.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/version0.9.html
+++ b/2/whatsnew/version0.9.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/version0.9.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/version1.0.html
+++ b/2/whatsnew/version1.0.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/version1.0.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/2/whatsnew/version2.0.html
+++ b/2/whatsnew/version2.0.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/whatsnew/version2.0.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/about/history.html
+++ b/3/about/history.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/about/history.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/about/index.html
+++ b/3/about/index.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/about/index.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/about/license_and_copyright.html
+++ b/3/about/license_and_copyright.html
@@ -30,7 +30,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/about/license_and_copyright.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.alias.html
+++ b/3/api/generated/IPython.core.alias.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.alias.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.application.html
+++ b/3/api/generated/IPython.core.application.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.application.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.autocall.html
+++ b/3/api/generated/IPython.core.autocall.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.autocall.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.builtin_trap.html
+++ b/3/api/generated/IPython.core.builtin_trap.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.builtin_trap.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.compilerop.html
+++ b/3/api/generated/IPython.core.compilerop.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.compilerop.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.completer.html
+++ b/3/api/generated/IPython.core.completer.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.completer.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.completerlib.html
+++ b/3/api/generated/IPython.core.completerlib.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.completerlib.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.crashhandler.html
+++ b/3/api/generated/IPython.core.crashhandler.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.crashhandler.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.debugger.html
+++ b/3/api/generated/IPython.core.debugger.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.debugger.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.error.html
+++ b/3/api/generated/IPython.core.error.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.error.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.events.html
+++ b/3/api/generated/IPython.core.events.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.events.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.excolors.html
+++ b/3/api/generated/IPython.core.excolors.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.excolors.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.extensions.html
+++ b/3/api/generated/IPython.core.extensions.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.extensions.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.formatters.html
+++ b/3/api/generated/IPython.core.formatters.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.formatters.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.getipython.html
+++ b/3/api/generated/IPython.core.getipython.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.getipython.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.history.html
+++ b/3/api/generated/IPython.core.history.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.history.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.historyapp.html
+++ b/3/api/generated/IPython.core.historyapp.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.historyapp.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.hooks.html
+++ b/3/api/generated/IPython.core.hooks.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.hooks.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.inputsplitter.html
+++ b/3/api/generated/IPython.core.inputsplitter.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.inputsplitter.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.inputtransformer.html
+++ b/3/api/generated/IPython.core.inputtransformer.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.inputtransformer.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.interactiveshell.html
+++ b/3/api/generated/IPython.core.interactiveshell.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.interactiveshell.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.logger.html
+++ b/3/api/generated/IPython.core.logger.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.logger.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.macro.html
+++ b/3/api/generated/IPython.core.macro.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.macro.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">

--- a/3/api/generated/IPython.core.magic.html
+++ b/3/api/generated/IPython.core.magic.html
@@ -31,7 +31,8 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 
-  </head>
+     <link rel="canonical" href="http://ipython.readthedocs.io/en/stable/api/generated/IPython.core.magic.html"/>
+</head>
   <body role="document">
 
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">


### PR DESCRIPTION
Do that only when the new page exists (ie status == 200)

---

Hopefully that can start to move some of google referencing of old version of IPython's doc out of the way. 

I was unsure whether to use stable or latest so I copied what readthedocs is doing. Everything point to stable. 
